### PR TITLE
Implemented fix for tracking latest packetIds of ordered packets when…

### DIFF
--- a/Source/BCClientPlugin/Private/BrainCloudRelayComms.h
+++ b/Source/BCClientPlugin/Private/BrainCloudRelayComms.h
@@ -214,4 +214,11 @@ private:
     // Memory
     Pool<Event> m_eventPool;
     Pool<Packet> m_packetPool;
+
+    // Tracking packet IDs for each player
+    // index of array represents channel ids 0 to 3
+    // TMap value has the player netId as the key
+    // And the tracked packetId as the value
+    // Data is structured this way because once it is used to update the client it will then be discarded
+    TArray<TMap<uint8, int>> m_trackedPacketIds;
 };


### PR DESCRIPTION
Implemented a fix for tracking the ordered packet Ids that were sent to the relay server before a client joins an in-progress game session. 

Greg added an extra parameter of information that the connecting client receives in the NET_ID operation message, I implemented a way to catch this data and put it into a one-time use for updating the latest packetId for each netId in each channelId. 

