### PR TITLE
Patch for 5.2

### DIFF
--- a/Source/BCBlueprintSupport/Private/K2Node_BrainCloudCall.cpp
+++ b/Source/BCBlueprintSupport/Private/K2Node_BrainCloudCall.cpp
@@ -90,7 +90,7 @@ void UK2Node_BrainCloudCall::GetMenuActions(FBlueprintActionDatabaseRegistrar &A
                         UObjectProperty *ReturnProp = CastChecked<UObjectProperty>(Func->GetReturnProperty());
 // Unreal Engine Version is >= 4.25 OR in Unreal Engine 5
 #elif (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 25) || ENGINE_MAJOR_VERSION == 5 
-                        FObjectProperty *ReturnProp = CastChecked<FObjectProperty>(Func->GetReturnProperty());
+                        FObjectProperty *ReturnProp = CastFieldChecked<FObjectProperty>(Func->GetReturnProperty());
 #endif
 
                         AsyncTaskNode->ProxyFactoryFunctionName = Func->GetFName();


### PR DESCRIPTION
Changed CastChecked to CastFieldChecked to resolve engine crashing in 5.2

The crash would happen after building, opening a blueprint class and right clicking in an empty spot to bring up the blueprint context menu. After putting this in, the crash stopped happening.