### PR TITLE
Fixed issue with PushNotification empty test

### DIFF
--- a/Source/BCClientPlugin/Private/BrainCloudPushNotification.cpp
+++ b/Source/BCClientPlugin/Private/BrainCloudPushNotification.cpp
@@ -62,14 +62,15 @@ void BrainCloudPushNotification::registerPushNotificationDeviceToken(const FStri
 			false);
         }
         
-    }
+	}
+	else {
+		TSharedRef<FJsonObject> message = MakeShareable(new FJsonObject());
+		message->SetStringField(OperationParam::PushNotificationRegisterParamDeviceType.getValue(), type);
+		message->SetStringField(OperationParam::PushNotificationRegisterParamDeviceToken.getValue(), token);
 
-	TSharedRef<FJsonObject> message = MakeShareable(new FJsonObject());
-	message->SetStringField(OperationParam::PushNotificationRegisterParamDeviceType.getValue(), type);
-	message->SetStringField(OperationParam::PushNotificationRegisterParamDeviceToken.getValue(), token);
-
-	ServerCall *sc = new ServerCall(ServiceName::PushNotification, ServiceOperation::Register, message, callback);
-	_client->sendRequest(sc);
+		ServerCall* sc = new ServerCall(ServiceName::PushNotification, ServiceOperation::Register, message, callback);
+		_client->sendRequest(sc);
+	}
 }
 
 void BrainCloudPushNotification::sendSimplePushNotification(const FString &toProfileId, const FString &message, IServerCallback *callback)


### PR DESCRIPTION
This function was generating a warning which causes the unit test that tests this to fail. 

Instead of sending out a request when the token is empty, just queue the error callback and don't send out the request. Request is only sent out if the token is valid / not empty.

Green unit tests:

Linux: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_Linux_develop_internal/152
MacOS: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_MacOS_develop_internal/1164/
Windows: https://vmjenkins.bitheads.com/view/Dev_Unreal/job/bitHeads_BrainCloud_Client_UnitTest_UnrealEngine_Win64_develop_internal/1205/